### PR TITLE
Reformatting fixes

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,10 +1,10 @@
-annotated-types==0.7.0 ; python_version >= "3.9" and python_version < "4.0" \
+annotated-types==0.7.0 ; python_version >= "3.9" \
     --hash=sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53 \
     --hash=sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89
-colorama==0.4.6 ; python_version >= "3.9" and python_version < "4.0" and sys_platform == "win32" \
+colorama==0.4.6 ; python_version >= "3.9" and sys_platform == "win32" \
     --hash=sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44 \
     --hash=sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6
-coverage==7.6.12 ; python_version >= "3.9" and python_version < "4.0" \
+coverage==7.6.12 ; python_version >= "3.9" \
     --hash=sha256:00b2086892cf06c7c2d74983c9595dc511acca00665480b3ddff749ec4fb2a95 \
     --hash=sha256:0533adc29adf6a69c1baa88c3d7dbcaadcffa21afbed3ca7a225a440e4744bf9 \
     --hash=sha256:06097c7abfa611c91edb9e6920264e5be1d6ceb374efb4986f38b09eed4cb2fe \
@@ -71,16 +71,16 @@ coverage==7.6.12 ; python_version >= "3.9" and python_version < "4.0" \
 exceptiongroup==1.2.2 ; python_version >= "3.9" and python_version < "3.11" \
     --hash=sha256:3111b9d131c238bec2f8f516e123e14ba243563fb135d3fe885990585aa7795b \
     --hash=sha256:47c2edf7c6738fafb49fd34290706d1a1a2f4d1c6df275526b62cbb4aa5393cc
-iniconfig==2.0.0 ; python_version >= "3.9" and python_version < "4.0" \
+iniconfig==2.0.0 ; python_version >= "3.9" \
     --hash=sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3 \
     --hash=sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374
-packaging==24.2 ; python_version >= "3.9" and python_version < "4.0" \
+packaging==24.2 ; python_version >= "3.9" \
     --hash=sha256:09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759 \
     --hash=sha256:c228a6dc5e932d346bc5739379109d49e8853dd8223571c7c5b55260edc0b97f
-pluggy==1.5.0 ; python_version >= "3.9" and python_version < "4.0" \
+pluggy==1.5.0 ; python_version >= "3.9" \
     --hash=sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1 \
     --hash=sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669
-pydantic-core==2.27.2 ; python_version >= "3.9" and python_version < "4.0" \
+pydantic-core==2.27.2 ; python_version >= "3.9" \
     --hash=sha256:00bad2484fa6bda1e216e7345a798bd37c68fb2d97558edd584942aa41b7d278 \
     --hash=sha256:0296abcb83a797db256b773f45773da397da75a08f5fcaef41f2044adec05f50 \
     --hash=sha256:03d0f86ea3184a12f41a2d23f7ccb79cdb5a18e06993f8a45baa8dfec746f0e9 \
@@ -181,16 +181,16 @@ pydantic-core==2.27.2 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:f6f8e111843bbb0dee4cb6594cdc73e79b3329b526037ec242a3e49012495b3b \
     --hash=sha256:fa8e459d4954f608fa26116118bb67f56b93b209c39b008277ace29937453dc9 \
     --hash=sha256:fd1aea04935a508f62e0d0ef1f5ae968774a32afc306fb8545e06f5ff5cdf3ad
-pydantic==2.10.6 ; python_version >= "3.9" and python_version < "4.0" \
+pydantic==2.10.6 ; python_version >= "3.9" \
     --hash=sha256:427d664bf0b8a2b34ff5dd0f5a18df00591adcee7198fbd71981054cef37b584 \
     --hash=sha256:ca5daa827cce33de7a42be142548b0096bf05a7e7b365aebfa5f8eeec7128236
-pymarc==5.2.3 ; python_version >= "3.9" and python_version < "4.0" \
+pymarc==5.2.3 ; python_version >= "3.9" \
     --hash=sha256:02a151d89c3b36f92bbc92c2e972bcfe91b91fc93529d8862e5f7c292a15c9f0 \
     --hash=sha256:9e0b2fff0f97764889fe2af08a93d137e0a46630c006c6330bebf0bdcd52201a
-pytest-cov==6.0.0 ; python_version >= "3.9" and python_version < "4.0" \
+pytest-cov==6.0.0 ; python_version >= "3.9" \
     --hash=sha256:eee6f1b9e61008bd34975a4d5bab25801eb31898b032dd55addc93e96fcaaa35 \
     --hash=sha256:fde0b595ca248bb8e2d76f020b465f3b107c9632e6a1d1705f17834c89dcadc0
-pytest==8.3.5 ; python_version >= "3.9" and python_version < "4.0" \
+pytest==8.3.5 ; python_version >= "3.9" \
     --hash=sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820 \
     --hash=sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845
 tomli==2.2.1 ; python_version >= "3.9" and python_full_version <= "3.11.0a6" \
@@ -226,6 +226,6 @@ tomli==2.2.1 ; python_version >= "3.9" and python_full_version <= "3.11.0a6" \
     --hash=sha256:e85e99945e688e32d5a35c1ff38ed0b3f41f43fad8df0bdf79f72b2ba7bc5272 \
     --hash=sha256:ece47d672db52ac607a3d9599a9d48dcb2f2f735c6c2d1f34130085bb12b112a \
     --hash=sha256:f4039b9cbc3048b2416cc57ab3bda989a6fcf9b36cf8937f01a6e731b64f80d7
-typing-extensions==4.12.2 ; python_version >= "3.9" and python_version < "4.0" \
+typing-extensions==4.12.2 ; python_version >= "3.9" \
     --hash=sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d \
     --hash=sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8

--- a/poetry.lock
+++ b/poetry.lock
@@ -405,5 +405,5 @@ files = [
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.9"
-content-hash = "9a51ea30d10bc615f1878371517e5bee8cb12c594022cf70b945f13e72efa42a"
+python-versions = ">=3.9"
+content-hash = "899f99bf9157faf8d2d1507f2e8010e1ca400b47f0f87f2a966f31e15082bf01"

--- a/pydantic_marc/__init__.py
+++ b/pydantic_marc/__init__.py
@@ -1,1 +1,1 @@
-from .models import MarcRecord, ControlField, DataField  # noqa: F401
+from .models import ControlField, DataField, MarcRecord  # noqa: F401

--- a/pydantic_marc/errors.py
+++ b/pydantic_marc/errors.py
@@ -8,8 +8,10 @@ required in order to wrap the exception within a `ValidationError` object.
 """
 
 from __future__ import annotations
+
 from typing import Any, Dict
-from pydantic_core import PydanticCustomError, InitErrorDetails
+
+from pydantic_core import InitErrorDetails, PydanticCustomError
 
 
 class MarcCustomError(PydanticCustomError):

--- a/pydantic_marc/models.py
+++ b/pydantic_marc/models.py
@@ -1,20 +1,23 @@
 """"""
 
 from __future__ import annotations
+
 from typing import Annotated, Any, Dict, List, Literal, Union
+
 from pydantic import (
     AfterValidator,
-    BeforeValidator,
     BaseModel,
+    BeforeValidator,
     Discriminator,
     Field,
-    model_serializer,
     Tag,
     WrapValidator,
+    model_serializer,
 )
 from pymarc import Indicators as PymarcIndicators
 from pymarc import Leader as PymarcLeader
 from pymarc import Subfield as PymarcSubfield
+
 from pydantic_marc.rules import MARC_RULES
 from pydantic_marc.validators import (
     validate_control_field,

--- a/pydantic_marc/rules.py
+++ b/pydantic_marc/rules.py
@@ -27,7 +27,6 @@ associated rules. The rules defined for each field include:
 
 from typing import Any, Dict
 
-
 MARC_RULES: Dict[str, Any] = {
     "001": {
         "repeatable": False,

--- a/pydantic_marc/validators.py
+++ b/pydantic_marc/validators.py
@@ -7,17 +7,19 @@ or wrap validators.
 
 from collections import Counter
 from typing import Any, Dict, List, Optional
-from pydantic import ValidationInfo, ValidationError, ValidatorFunctionWrapHandler
+
+from pydantic import ValidationError, ValidationInfo, ValidatorFunctionWrapHandler
 from pymarc import Field as PymarcField
+
 from pydantic_marc.errors import (
+    ControlFieldLength,
     InvalidIndicator,
     InvalidSubfield,
-    NonRepeatableField,
-    NonRepeatableSubfield,
+    MarcCustomError,
     MissingRequiredField,
     MultipleMainEntryValues,
-    ControlFieldLength,
-    MarcCustomError,
+    NonRepeatableField,
+    NonRepeatableSubfield,
 )
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 license = "MIT"
 readme = "README.md"
-requires-python = "^3.9"
+requires-python = ">=3.9"
 dependencies = [
     "pymarc (>=5.2.3,<6.0.0)",
     "pydantic (>=2.10.6,<3.0.0)"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-annotated-types==0.7.0 ; python_version >= "3.9" and python_version < "4.0" \
+annotated-types==0.7.0 ; python_version >= "3.9" \
     --hash=sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53 \
     --hash=sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89
-pydantic-core==2.27.2 ; python_version >= "3.9" and python_version < "4.0" \
+pydantic-core==2.27.2 ; python_version >= "3.9" \
     --hash=sha256:00bad2484fa6bda1e216e7345a798bd37c68fb2d97558edd584942aa41b7d278 \
     --hash=sha256:0296abcb83a797db256b773f45773da397da75a08f5fcaef41f2044adec05f50 \
     --hash=sha256:03d0f86ea3184a12f41a2d23f7ccb79cdb5a18e06993f8a45baa8dfec746f0e9 \
@@ -102,12 +102,12 @@ pydantic-core==2.27.2 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:f6f8e111843bbb0dee4cb6594cdc73e79b3329b526037ec242a3e49012495b3b \
     --hash=sha256:fa8e459d4954f608fa26116118bb67f56b93b209c39b008277ace29937453dc9 \
     --hash=sha256:fd1aea04935a508f62e0d0ef1f5ae968774a32afc306fb8545e06f5ff5cdf3ad
-pydantic==2.10.6 ; python_version >= "3.9" and python_version < "4.0" \
+pydantic==2.10.6 ; python_version >= "3.9" \
     --hash=sha256:427d664bf0b8a2b34ff5dd0f5a18df00591adcee7198fbd71981054cef37b584 \
     --hash=sha256:ca5daa827cce33de7a42be142548b0096bf05a7e7b365aebfa5f8eeec7128236
-pymarc==5.2.3 ; python_version >= "3.9" and python_version < "4.0" \
+pymarc==5.2.3 ; python_version >= "3.9" \
     --hash=sha256:02a151d89c3b36f92bbc92c2e972bcfe91b91fc93529d8862e5f7c292a15c9f0 \
     --hash=sha256:9e0b2fff0f97764889fe2af08a93d137e0a46630c006c6330bebf0bdcd52201a
-typing-extensions==4.12.2 ; python_version >= "3.9" and python_version < "4.0" \
+typing-extensions==4.12.2 ; python_version >= "3.9" \
     --hash=sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d \
     --hash=sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,6 @@
 import pytest
-
-from pymarc import Indicators, Record, Subfield
 from pymarc import Field as PymarcField
+from pymarc import Indicators, Record, Subfield
 
 
 @pytest.fixture

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -1,13 +1,14 @@
 import pytest
 from pymarc import Subfield as PymarcSubfield
+
 from pydantic_marc.errors import (
+    ControlFieldLength,
     InvalidIndicator,
     InvalidSubfield,
-    NonRepeatableField,
-    NonRepeatableSubfield,
     MissingRequiredField,
     MultipleMainEntryValues,
-    ControlFieldLength,
+    NonRepeatableField,
+    NonRepeatableSubfield,
 )
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -3,8 +3,9 @@ from pydantic import ValidationError
 from pymarc import Field as PymarcField
 from pymarc import Indicators as PymarcIndicators
 from pymarc import Leader as PymarcLeader
-from pymarc import Subfield as PymarcSubfield
 from pymarc import MARCReader
+from pymarc import Subfield as PymarcSubfield
+
 from pydantic_marc.models import ControlField, DataField, MarcRecord
 from pydantic_marc.rules import MARC_RULES
 

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,4 +1,5 @@
 import pytest
+
 from pydantic_marc.rules import MARC_RULES
 
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -1,16 +1,18 @@
 from typing import Any, Dict, Optional
+
 import pytest
-from pymarc import Indicators, Subfield
 from pydantic import TypeAdapter
+from pymarc import Indicators, Subfield
+
+from pydantic_marc.models import ControlField
+from pydantic_marc.rules import MARC_RULES
 from pydantic_marc.validators import (
     check_marc_rules,
     validate_control_field,
+    validate_fields,
     validate_indicators,
     validate_subfields,
-    validate_fields,
 )
-from pydantic_marc.models import ControlField
-from pydantic_marc.rules import MARC_RULES
 
 
 class MockInfo:


### PR DESCRIPTION
 - Reformatted files with `ruff` to organize imports and clean up formatting mistakes.
 - Fixed typo in `pyproject.toml`. 
 - Updated `poetry.lock`, `requirements.txt` and `dev-requirements.txt`.